### PR TITLE
Implement custom design system, replacing PaperMod placeholder theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "themes/PaperMod"]
-	path = themes/PaperMod
-	url = https://github.com/adityatelange/hugo-PaperMod.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,12 +11,31 @@ of truth for the site's intended visual design (bespoke typography, sidenotes,
 TOC, content-type tags, print stylesheet, Writing/Projects/Photos/Food/About
 nav) — implement against these, not from scratch.
 
-**The current build does not yet match this spec.** It's running the stock
-PaperMod theme (`themes/PaperMod`) as an interim placeholder so the Cloudflare
-Pages migration could ship independently of the design work. Building the
-custom theme described in `design/` is a separate, not-yet-started piece of
-work — don't assume PaperMod's structure (menus, archive layout, RSS partial,
-etc.) is the target; check `design/DESIGN.md` first.
+The custom theme is implemented directly in `layouts/` and `assets/css/main.css`
+(no theme submodule — PaperMod has been removed). Key pieces:
+
+- `layouts/baseof.html` + `layouts/_partials/{head,header,footer,social-icons,feed-item}.html`
+  — shared chrome.
+- `layouts/posts/single.html` — article template (preface, auto-generated TOC
+  from `.TableOfContents`, footnotes via goldmark). Sidenotes and "back to
+  contents" links are authored per-article via the `{{< sidenote >}}`,
+  `{{< ref >}}` and `{{< backtotoc >}}` shortcodes in `layouts/_shortcodes/`
+  — use angle-bracket `{{< >}}` delimiters for these, not `{{% %}}`, since
+  goldmark's `unsafe = false` strips raw HTML emitted by percent-delimited
+  shortcode output.
+- `layouts/posts/single.html` also handles Link-type posts (front matter
+  `externalURL` set) with a stripped-down template instead of the full
+  article layout.
+- Photos/Food/Projects each have `list.html` (card grid + a permanent
+  "More soon" empty-state card) and `single.html` (gallery grid / recipe
+  card respectively).
+- Home feed (`layouts/index.html`, `layouts/index.rss.xml`) aggregates
+  `posts` + `photos` + `food` sections by date; `projects` is excluded
+  (standalone page per the design spec).
+- `[outputs]` in `hugo.toml` restricts non-home page kinds to `["HTML"]` —
+  Hugo's default of also emitting RSS for every section would otherwise
+  scatter stray `/posts/feed.xml`-style files and defeat `uglyURLs` on
+  those sections.
 
 ## Content conventions
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,0 +1,335 @@
+/* ============================================================
+   TOKENS
+   Single baked-in accent (orange) — no runtime theme switcher.
+   See design/DESIGN.md for the source spec.
+   ============================================================ */
+:root{
+  --bg: #ffffff;
+  --bg-subtle: #f5f6f8;
+  --bg-inset: #eef0f3;
+  --text: #14171c;
+  --text-muted: #5b6472;
+  --border: #e3e6ea;
+
+  --font-serif: Georgia, 'Iowan Old Style', 'Palatino Linotype', 'Times New Roman', serif;
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  --font-mono: ui-monospace, 'SF Mono', 'Cascadia Code', 'Consolas', monospace;
+
+  --accent: #E8541F;
+  --accent-soft: #FBEAE2;
+  --accent-strong: #B23E14;
+
+  --measure: 640px;
+  --note-width: 220px;
+  --note-gap: 28px;
+}
+
+*{ box-sizing:border-box; }
+html{ scroll-behavior:smooth; }
+body{
+  margin:0;
+  background:var(--bg);
+  color:var(--text);
+  font-family:var(--font-sans);
+  line-height:1.5;
+  -webkit-font-smoothing:antialiased;
+}
+a{ color:inherit; }
+img{ max-width:100%; display:block; }
+::selection{ background:var(--accent-soft); }
+:focus-visible{ outline:2px solid var(--accent); outline-offset:2px; }
+@media (prefers-reduced-motion: reduce){
+  html{ scroll-behavior:auto; }
+  *{ animation-duration:0.001ms !important; transition-duration:0.001ms !important; }
+}
+
+/* ============================================================
+   SITE CHROME
+   ============================================================ */
+.site-header{
+  max-width:900px; margin:0 auto; padding:28px 20px 20px;
+  display:flex; align-items:baseline; justify-content:space-between;
+  border-bottom:1px solid var(--border);
+}
+.wordmark{
+  font-family:var(--font-serif); font-size:22px; font-weight:700;
+  text-decoration:none; color:var(--text);
+}
+.wordmark span{ color:var(--accent); }
+.site-header nav{ display:flex; align-items:center; gap:20px; flex-wrap:wrap; flex:1; }
+.site-header nav a{
+  font-family:var(--font-sans); font-size:14px; text-decoration:none;
+  color:var(--text-muted);
+}
+.site-header nav a:hover{ color:var(--text); }
+.site-header nav a[aria-current="page"]{ color:var(--accent-strong); font-weight:600; }
+.nav-icons{ display:flex; align-items:center; gap:14px; margin-left:auto; }
+.icon-btn{ display:inline-flex; color:var(--text-muted); }
+.icon-btn:hover{ color:var(--accent); }
+.icon-btn svg{ width:17px; height:17px; }
+
+@media (max-width:700px){
+  .site-header{ flex-direction:column; align-items:flex-start; gap:14px; }
+  .site-header nav{ gap:14px; }
+  .nav-icons{ margin-left:0; }
+}
+
+main{ max-width:900px; margin:0 auto; padding:0 20px; }
+
+/* ============================================================
+   HOME FEED
+   Tags encode content type — reader knows before clicking whether
+   something is a full article, an outbound link, a gallery or a
+   recipe.
+   ============================================================ */
+.feed{ padding:36px 0 10px; max-width:var(--measure); }
+.feed-item{ padding:26px 0; border-bottom:1px solid var(--border); }
+.feed-item:first-child{ padding-top:0; }
+.tag{
+  font-family:var(--font-mono); font-size:11px; letter-spacing:0.06em;
+  text-transform:uppercase; color:var(--accent-strong);
+  background:var(--accent-soft); padding:2px 7px; border-radius:3px;
+}
+.feed-meta{
+  display:flex; align-items:center; gap:10px; margin-bottom:8px;
+  font-family:var(--font-mono); font-size:12px; color:var(--text-muted);
+}
+.feed-item h3{
+  font-family:var(--font-serif); font-size:22px; margin:0 0 8px; line-height:1.3;
+}
+.feed-item h3 a{ text-decoration:none; }
+.feed-item h3 a:hover{ text-decoration:underline; text-decoration-color:var(--accent); }
+.feed-item p{ margin:0 0 8px; color:#333; }
+.feed-item .more{
+  font-family:var(--font-mono); font-size:13px; color:var(--accent-strong);
+  text-decoration:none;
+}
+.link-post h3::before{ content:"→ "; color:var(--accent); }
+.thumb-row{ display:flex; gap:6px; margin-top:10px; flex-wrap:wrap; }
+.thumb-row .thumb{ width:64px; height:44px; border-radius:3px; overflow:hidden; }
+.thumb-row .thumb img{ width:100%; height:100%; object-fit:cover; }
+
+/* ============================================================
+   ARTICLE — Preface / TOC / Article, with margin sidenotes
+   ============================================================ */
+.article-wrap{ max-width:900px; margin:0 auto; padding:44px 20px 10px; }
+.article-head{ max-width:var(--measure); }
+.article-head .feed-meta{ margin-bottom:14px; }
+.print-btn{
+  font-family:var(--font-mono); font-size:12px; color:var(--text-muted);
+  background:none; border:1px solid var(--border); border-radius:4px;
+  padding:3px 9px; cursor:pointer; margin-left:auto;
+}
+.print-btn:hover{ border-color:var(--accent); color:var(--accent-strong); }
+h1.title{
+  font-family:var(--font-serif); font-size:38px; line-height:1.15;
+  margin:0 0 18px;
+}
+@media (max-width:480px){
+  h1.title{ font-size:28px; }
+  .preface{ font-size:17px; }
+  .article-wrap{ padding-top:32px; }
+  .site-header{ padding-top:20px; }
+}
+.preface{
+  font-family:var(--font-serif); font-size:19px; font-style:italic;
+  color:#333; max-width:var(--measure); margin:0 0 26px; line-height:1.55;
+}
+.toc{
+  max-width:var(--measure); border:1px solid var(--border); border-radius:6px;
+  padding:16px 20px; margin:0 0 40px; background:var(--bg-subtle);
+}
+.toc-label{
+  font-family:var(--font-mono); font-size:11px; letter-spacing:0.08em;
+  text-transform:uppercase; color:var(--text-muted); margin-bottom:8px;
+}
+.toc nav{ display:block; }
+.toc ol, .toc ul{ list-style:none; margin:0; padding:0; counter-reset:toc; }
+.toc ul ul{ counter-reset:none; padding-left:20px; }
+.toc li{ counter-increment:toc; margin:4px 0; }
+.toc li::before{
+  content:counter(toc, decimal-leading-zero); font-family:var(--font-mono);
+  font-size:12px; color:var(--accent-strong); margin-right:10px;
+}
+.toc a{ text-decoration:none; font-size:15px; }
+.toc a:hover{ text-decoration:underline; }
+
+.article-body{ max-width:var(--measure); font-family:var(--font-serif); font-size:17px; }
+.article-body h2{
+  font-family:var(--font-serif); font-size:24px; margin:40px 0 14px;
+  scroll-margin-top:70px;
+}
+.article-body p{ margin:0 0 16px; }
+.article-body img{ max-width:100%; border-radius:6px; margin:0 0 20px; }
+.back-to-toc{
+  display:inline-block; font-family:var(--font-mono); font-size:11px;
+  color:var(--text-muted); text-decoration:none; margin:2px 0 26px;
+}
+.back-to-toc:hover{ color:var(--accent-strong); }
+
+/* Sidenotes: float into the margin gutter on wide screens,
+   collapse to an inline callout on narrow ones. Single source
+   of content — no duplication needed. */
+.sidenote{
+  float:right; clear:right;
+  width:var(--note-width);
+  margin-right:calc(-1 * (var(--note-width) + var(--note-gap)));
+  margin-top:2px;
+  font-family:var(--font-sans); font-size:13px; line-height:1.5;
+  color:var(--text-muted);
+  border-left:2px solid var(--accent); padding-left:10px;
+}
+.sidenote .num{ color:var(--accent-strong); font-family:var(--font-mono); }
+sup.ref{ color:var(--accent-strong); font-family:var(--font-mono); font-size:11px; }
+
+@media (max-width: 1099px){
+  .sidenote{
+    float:none; width:auto; margin:14px 0; padding:10px 12px;
+    background:var(--bg-subtle); border-left:3px solid var(--accent);
+  }
+}
+
+pre{
+  background:#1c1f24; color:#d9dde3; border-radius:6px;
+  padding:16px 18px; overflow-x:auto; margin:0 0 20px;
+  border-left:3px solid var(--accent);
+}
+code{ font-family:var(--font-mono); font-size:13px; }
+p code, li code{
+  background:var(--bg-inset); padding:1px 5px; border-radius:3px; font-size:0.85em;
+}
+/* Chroma applies its own "chroma" class directly to the <pre> it renders,
+   inside a wrapping .highlight div — style the pre itself. */
+.highlight{ margin:0 0 20px; }
+pre.chroma{ margin:0; }
+
+.footnotes{
+  max-width:var(--measure); margin-top:20px; padding-top:20px;
+  border-top:1px solid var(--border);
+  font-family:var(--font-sans); font-size:14px; color:var(--text-muted);
+}
+.footnotes ol{ padding-left:20px; }
+.footnotes li{ margin-bottom:8px; }
+.footnotes hr{ display:none; }
+
+/* ============================================================
+   PROJECTS
+   ============================================================ */
+.projects-section{ max-width:900px; margin:0 auto; padding:50px 20px 60px; }
+.projects-section h1{ font-family:var(--font-serif); font-size:26px; margin:0 0 4px; }
+.projects-section .sub{ color:var(--text-muted); margin:0 0 20px; font-size:14px; }
+.projects-grid{ display:grid; grid-template-columns:repeat(auto-fit, minmax(240px,1fr)); gap:16px; }
+.project-card{ border:1px solid var(--border); border-radius:8px; padding:20px 22px; }
+.project-card h2{ font-family:var(--font-serif); font-size:18px; margin:0 0 8px; }
+.project-card p{ font-size:14px; color:#333; margin:0 0 14px; }
+.project-links{ display:flex; gap:16px; font-family:var(--font-mono); font-size:12px; }
+.project-links a{ color:var(--accent-strong); text-decoration:none; }
+.project-links a:hover{ text-decoration:underline; }
+
+/* Reusable pattern for a section with nothing in it yet.
+   Same card shape as populated content, dashed instead of solid,
+   so it reads as "reserved" rather than "broken". */
+.empty-state{
+  border-style:dashed; background:var(--bg-subtle);
+  display:flex; flex-direction:column; justify-content:center;
+}
+.empty-state .eyebrow{
+  font-family:var(--font-mono); font-size:11px; letter-spacing:0.06em;
+  text-transform:uppercase; color:var(--text-muted); margin-bottom:6px;
+}
+.empty-state p{ color:var(--text-muted); font-style:italic; margin:0; font-size:14px; }
+
+
+.gallery-section{ max-width:900px; margin:0 auto; padding:50px 20px 60px; }
+.gallery-section h1{ font-family:var(--font-serif); font-size:26px; margin:0 0 4px; }
+.gallery-section .sub{ color:var(--text-muted); margin:0 0 20px; font-size:14px; }
+.gallery-grid{
+  display:grid; grid-template-columns:repeat(auto-fill, minmax(160px,1fr));
+  gap:12px;
+}
+.gallery-grid figure{ margin:0; }
+.gallery-grid figure a{
+  display:block; aspect-ratio:4/3; border-radius:6px; overflow:hidden;
+  border:1px solid var(--border);
+}
+.gallery-grid figure a img{ width:100%; height:100%; object-fit:cover; }
+.gallery-grid .ph{
+  aspect-ratio:4/3; border-radius:6px;
+  background:linear-gradient(135deg, var(--accent-soft), var(--bg-inset));
+  border:1px solid var(--border);
+  display:flex; align-items:center; justify-content:center;
+  font-family:var(--font-mono); font-size:11px; color:var(--accent-strong);
+}
+.gallery-grid figcaption{
+  font-family:var(--font-mono); font-size:11px; color:var(--text-muted);
+  margin-top:6px;
+}
+
+/* ============================================================
+   RECIPE
+   ============================================================ */
+.recipe-section{ max-width:900px; margin:0 auto; padding:50px 20px 60px; }
+.recipe-card{
+  max-width:var(--measure); border:1px solid var(--border); border-radius:8px;
+  padding:24px 26px; background:var(--bg-subtle);
+}
+.recipe-card h1{ font-family:var(--font-serif); font-size:24px; margin:0 0 4px; }
+.recipe-card .sub{ color:var(--text-muted); font-size:14px; margin:0 0 18px; }
+.recipe-cols{ display:grid; grid-template-columns:1fr 1.6fr; gap:26px; }
+.recipe-cols h4{
+  font-family:var(--font-mono); font-size:11px; letter-spacing:0.06em;
+  text-transform:uppercase; color:var(--accent-strong); margin:0 0 10px;
+}
+.recipe-cols ul, .recipe-cols ol{ margin:0; padding-left:18px; font-size:14px; }
+.recipe-cols li{ margin-bottom:8px; }
+.recipe-note{ margin-top:26px; }
+@media (max-width:600px){ .recipe-cols{ grid-template-columns:1fr; } }
+
+/* ============================================================
+   GENERIC PAGE (About, etc.)
+   ============================================================ */
+.page-section{ max-width:900px; margin:0 auto; padding:44px 20px 60px; }
+.page-section .page-body{
+  max-width:var(--measure); font-family:var(--font-serif); font-size:17px;
+}
+.page-section h1.title{ max-width:var(--measure); }
+.page-section .page-body p{ margin:0 0 16px; }
+.page-section .project-links{ margin:0 0 24px; }
+
+/* ============================================================
+   404
+   ============================================================ */
+.not-found{
+  max-width:var(--measure); margin:0 auto; padding:80px 20px;
+  font-family:var(--font-serif); font-size:19px; text-align:center;
+  color:var(--text-muted);
+}
+.not-found p{ margin:0 0 12px; }
+.not-found a{ color:var(--accent-strong); }
+
+/* ============================================================
+   FOOTER
+   ============================================================ */
+.site-footer{
+  max-width:900px; margin:60px auto 0; padding:24px 20px 40px;
+  border-top:1px solid var(--border);
+  display:flex; align-items:center; justify-content:space-between;
+  flex-wrap:wrap; gap:14px;
+}
+.social{ display:flex; gap:14px; }
+.social a{ color:var(--text-muted); }
+.social a:hover{ color:var(--accent); }
+.social svg{ width:19px; height:19px; }
+.site-footer small{ color:var(--text-muted); font-family:var(--font-mono); font-size:12px; }
+
+/* ============================================================
+   PRINT — nav, footer and thumbnails drop out; sidenotes fall
+   inline; single serif column.
+   ============================================================ */
+@media print{
+  .site-header nav, .icon-btn, .site-footer, .print-btn{ display:none !important; }
+  body{ font-size:12pt; }
+  .sidenote{ float:none; width:auto; margin:8px 0; border-left:1px solid #999; background:none; }
+  a{ text-decoration:none; color:#000; }
+  .toc{ border:1px solid #999; background:none; }
+}

--- a/content/food/_index.md
+++ b/content/food/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Food"
+description: "Recipes I actually cook."
+---

--- a/content/photos/_index.md
+++ b/content/photos/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Photos"
+description: "Galleries from what I've been up to."
+---

--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Projects"
+description: "Things I've built and shipped."
+---

--- a/content/projects/home-network.md
+++ b/content/projects/home-network.md
@@ -2,6 +2,7 @@
 title: "Home Network"
 date: 2025-12-05
 draft: true
+summary: "Ubiquiti gear, VLANs for Sonos and Home Assistant, and the write-up of getting it all to play nicely together."
 ---
 
 My Home Network

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,7 +1,6 @@
 baseURL = "https://eddarmitage.com/"
-locale = "en-gb"
+locale = "en-GB"
 title = "Edd Armitage - Software Engineer"
-theme = "PaperMod"
 
 uglyURLs = true
 disableKinds = ["taxonomy", "term"]
@@ -15,16 +14,25 @@ disableKinds = ["taxonomy", "term"]
 
 [outputs]
   home = ["HTML", "RSS"]
+  section = ["HTML"]
+  taxonomy = ["HTML"]
+  term = ["HTML"]
+  page = ["HTML"]
+
+[markup.goldmark.renderer]
+  unsafe = false
+
+[markup.goldmark.extensions.footnote]
+  enable = true
+
+[markup.highlight]
+  noClasses = false
+  style = "monokai"
 
 [params]
   description = "The personal website of a software engineer"
   author = "Edd Armitage"
-  ShowReadingTime = false
-  ShowShareButtons = false
-  ShowPostNavLinks = true
-  ShowBreadCrumbs = false
-  ShowCodeCopyButtons = true
-  mainSections = ["posts"]
+  mainSections = ["posts", "photos", "food"]
 
   [params.assets]
     favicon = "assets/favicon.ico"
@@ -40,17 +48,39 @@ disableKinds = ["taxonomy", "term"]
     url = "https://github.com/eddarmitage"
 
   [[params.socialIcons]]
+    name = "instagram"
+    url = "https://www.instagram.com/eddarmitage"
+
+  [[params.socialIcons]]
     name = "linkedin"
     url = "https://www.linkedin.com/in/eddarmitage"
+
+[[menu.main]]
+  identifier = "writing"
+  name = "Writing"
+  url = "/posts/"
+  weight = 10
+
+[[menu.main]]
+  identifier = "projects"
+  name = "Projects"
+  url = "/projects/"
+  weight = 20
+
+[[menu.main]]
+  identifier = "photos"
+  name = "Photos"
+  url = "/photos/"
+  weight = 30
+
+[[menu.main]]
+  identifier = "food"
+  name = "Food"
+  url = "/food/"
+  weight = 40
 
 [[menu.main]]
   identifier = "about"
   name = "About"
   url = "/about"
-  weight = 10
-
-[[menu.main]]
-  identifier = "archive"
-  name = "Archive"
-  url = "/archive"
-  weight = 20
+  weight = 50

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,3 +1,6 @@
 {{- define "main" }}
-<div class="not-found">Oh no. That page seems to be missing.</div>
+<div class="not-found">
+  <p>Oh no. That page seems to be missing.</p>
+  <p><a href="{{ "/" | relURL }}">Back to the front page &rarr;</a></p>
+</div>
 {{- end }}{{/* end main */ -}}

--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -1,0 +1,13 @@
+{{- define "main" }}
+<section class="feed">
+  {{- $posts := where site.RegularPages "Section" "posts" }}
+  {{- $posts = $posts.ByDate.Reverse }}
+  {{- if $posts }}
+  {{- range $posts }}
+  {{- partial "feed-item.html" . }}
+  {{- end }}
+  {{- else }}
+  <p>Nothing published yet.</p>
+  {{- end }}
+</section>
+{{- end }}{{/* end main */}}

--- a/layouts/_partials/feed-item.html
+++ b/layouts/_partials/feed-item.html
@@ -1,0 +1,35 @@
+{{- /* Renders one home/section feed card. Context: a regular Page from posts/photos/food. */}}
+{{- $isLink := .Params.externalURL }}
+{{- $isPhotos := eq .Section "photos" }}
+{{- $isFood := eq .Section "food" }}
+{{- $tag := "Article" }}
+{{- if $isLink }}{{ $tag = "Link" }}{{ else if $isPhotos }}{{ $tag = "Photos" }}{{ else if $isFood }}{{ $tag = "Food" }}{{ end }}
+{{- $href := .Permalink }}
+{{- if $isLink }}{{ $href = $isLink }}{{ end }}
+
+<article class="feed-item{{ if $isLink }} link-post{{ end }}">
+  <div class="feed-meta">
+    <span class="tag">{{ $tag }}</span> {{ .Date.Format "2 Jan 2006" }}{{ if eq $tag "Article" }} &middot; {{ .ReadingTime }} min read{{ end }}
+  </div>
+  <h3>
+    {{- if $isLink }}
+    <a href="{{ $href }}" target="_blank" rel="noopener noreferrer">{{ .Title }}</a>
+    {{- else }}
+    <a href="{{ $href }}">{{ .Title }}</a>
+    {{- end }}
+  </h3>
+  <p>{{ with .Params.description }}{{ . }}{{ else }}{{ .Summary | plainify }}{{ end }}</p>
+  {{- if eq $tag "Article" }}
+  <a class="more" href="{{ .Permalink }}">Continue reading &rarr;</a>
+  {{- end }}
+  {{- if $isPhotos }}
+  {{- $images := .Resources.ByType "image" }}
+  {{- with $images }}
+  <div class="thumb-row">
+    {{- range first 4 . }}
+    <div class="thumb"><img src="{{ .RelPermalink }}" alt="{{ .Title }}" loading="lazy"></div>
+    {{- end }}
+  </div>
+  {{- end }}
+  {{- end }}
+</article>

--- a/layouts/_partials/footer.html
+++ b/layouts/_partials/footer.html
@@ -1,0 +1,6 @@
+<footer class="site-footer">
+  <div class="social">
+    {{- partial "social-icons.html" (dict "class" "") }}
+  </div>
+  <small>&copy; {{ now.Year }} Edd Armitage</small>
+</footer>

--- a/layouts/_partials/head.html
+++ b/layouts/_partials/head.html
@@ -1,0 +1,25 @@
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<title>{{ if .IsHome }}{{ site.Title }}{{ else }}{{ .Title }} | {{ site.Title }}{{ end }}</title>
+
+<meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ with .Summary }}{{ . | plainify }}{{ else }}{{ site.Params.description }}{{ end }}{{ end }}">
+<meta name="author" content="{{ site.Params.author }}">
+<link rel="canonical" href="{{ .Permalink }}">
+
+{{- $style := resources.Get "css/main.css" | minify | fingerprint }}
+<link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}">
+
+<link rel="icon" href="{{ site.Params.assets.favicon | absURL }}">
+<link rel="icon" type="image/png" sizes="16x16" href="{{ site.Params.assets.favicon16x16 | absURL }}">
+<link rel="icon" type="image/png" sizes="32x32" href="{{ site.Params.assets.favicon32x32 | absURL }}">
+<link rel="apple-touch-icon" href="{{ site.Params.assets.apple_touch_icon | absURL }}">
+<link rel="mask-icon" href="{{ site.Params.assets.safari_pinned_tab | absURL }}" color="{{ site.Params.assets.theme_color }}">
+<meta name="theme-color" content="{{ site.Params.assets.theme_color }}">
+<meta name="msapplication-TileColor" content="{{ site.Params.assets.msapplication_TileColor }}">
+
+{{- range .AlternativeOutputFormats }}
+<link rel="{{ .Rel }}" type="{{ .MediaType.Type | html }}" href="{{ .Permalink | safeURL }}" title="{{ site.Title }}">
+{{- end }}
+
+{{- partial "extend_head.html" . }}

--- a/layouts/_partials/header.html
+++ b/layouts/_partials/header.html
@@ -1,0 +1,11 @@
+<header class="site-header">
+  <a class="wordmark" href="{{ "/" | relURL }}">edd armitage<span>.</span></a>
+  <nav>
+    {{- range site.Menus.main }}
+    <a href="{{ .URL }}" {{ if $.IsMenuCurrent "main" . }}aria-current="page"{{ end }}>{{ .Name }}</a>
+    {{- end }}
+    <span class="nav-icons">
+      {{- partial "social-icons.html" (dict "class" "icon-btn") }}
+    </span>
+  </nav>
+</header>

--- a/layouts/_partials/social-icons.html
+++ b/layouts/_partials/social-icons.html
@@ -1,0 +1,24 @@
+{{- /*
+  Renders the GitHub/Instagram/LinkedIn/RSS icon cluster.
+  Usage: {{ partial "social-icons.html" (dict "ctx" . "class" "icon-btn") }}
+*/}}
+{{- $class := .class | default "" }}
+{{- range site.Params.socialIcons }}
+{{- $label := .name }}
+{{- if eq .name "github" }}{{ $label = "GitHub" }}
+{{- else if eq .name "linkedin" }}{{ $label = "LinkedIn" }}
+{{- else if eq .name "instagram" }}{{ $label = "Instagram" }}
+{{- end }}
+<a class="{{ $class }}" href="{{ trim .url " " | safeURL }}" target="_blank" rel="noopener noreferrer me" title="{{ $label }}">
+  {{- if eq .name "github" }}
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M9 19c-4.3 1.4-4.3-2.5-6-3m12 5v-3.5c0-1 .1-1.4-.5-2 2.8-.3 5.5-1.4 5.5-6a4.6 4.6 0 0 0-1.3-3.2 4.2 4.2 0 0 0-.1-3.2s-1.1-.3-3.5 1.3a12.3 12.3 0 0 0-6.2 0C6.5 2.8 5.4 3.1 5.4 3.1a4.2 4.2 0 0 0-.1 3.2A4.6 4.6 0 0 0 4 9.5c0 4.6 2.7 5.7 5.5 6-.6.6-.6 1.2-.5 2V21"/></svg>
+  {{- else if eq .name "instagram" }}
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="3" width="18" height="18" rx="5"/><circle cx="12" cy="12" r="4"/><circle cx="17.5" cy="6.5" r="0.8" fill="currentColor" stroke="none"/></svg>
+  {{- else if eq .name "linkedin" }}
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="8" y1="11" x2="8" y2="16"/><line x1="8" y1="8" x2="8" y2="8"/><path d="M12 16v-3a2 2 0 0 1 4 0v3"/></svg>
+  {{- end }}
+</a>
+{{- end }}
+<a class="{{ $class }}" href="{{ "feed.xml" | relURL }}" title="RSS feed">
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 11a9 9 0 0 1 9 9"/><path d="M4 4a16 16 0 0 1 16 16"/><circle cx="5" cy="19" r="1"/></svg>
+</a>

--- a/layouts/_shortcodes/backtotoc.html
+++ b/layouts/_shortcodes/backtotoc.html
@@ -1,0 +1,1 @@
+<a class="back-to-toc" href="#toc">&uarr; Back to contents</a>

--- a/layouts/_shortcodes/ref.html
+++ b/layouts/_shortcodes/ref.html
@@ -1,0 +1,1 @@
+<sup class="ref">{{ .Get 0 }}</sup>

--- a/layouts/_shortcodes/sidenote.html
+++ b/layouts/_shortcodes/sidenote.html
@@ -1,0 +1,2 @@
+{{- $num := .Get "num" | default (.Get 0) }}
+<div class="sidenote"><span class="num">{{ $num }}</span> &mdash; {{ .Inner }}</div>

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="{{ site.Language.Locale | default "en" }}">
+<head>
+{{- partial "head.html" . }}
+</head>
+<body>
+
+{{- partial "header.html" . }}
+
+<main>
+{{- block "main" . }}{{ end }}
+</main>
+
+{{- partial "footer.html" . }}
+
+</body>
+</html>

--- a/layouts/food/list.html
+++ b/layouts/food/list.html
@@ -1,0 +1,19 @@
+{{- define "main" }}
+<section class="projects-section">
+  <h1>{{ .Title }}</h1>
+  <p class="sub">{{ with .Params.description }}{{ . }}{{ else }}Recipes I actually cook.{{ end }}</p>
+  <div class="projects-grid">
+    {{- range .Pages.ByDate.Reverse }}
+    <article class="project-card">
+      <h2><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
+      <p>{{ with .Params.sub }}{{ . }}{{ else }}{{ .Summary | plainify }}{{ end }}</p>
+      <div class="project-links"><a href="{{ .Permalink }}">View recipe &rarr;</a></div>
+    </article>
+    {{- end }}
+    <article class="project-card empty-state">
+      <div class="eyebrow">More soon</div>
+      <p>Nothing here yet &mdash; the slot's ready, that's fine.</p>
+    </article>
+  </div>
+</section>
+{{- end }}{{/* end main */}}

--- a/layouts/food/single.html
+++ b/layouts/food/single.html
@@ -1,0 +1,31 @@
+{{- define "main" }}
+<section class="recipe-section">
+  <div class="recipe-card">
+    <h1>{{ .Title }}</h1>
+    {{- with .Params.sub }}<p class="sub">{{ . }}</p>{{- end }}
+    <div class="recipe-cols">
+      <div>
+        <h4>Ingredients</h4>
+        <ul>
+          {{- range .Params.ingredients }}
+          <li>{{ . }}</li>
+          {{- end }}
+        </ul>
+      </div>
+      <div>
+        <h4>Method</h4>
+        <ol>
+          {{- range .Params.method }}
+          <li>{{ . }}</li>
+          {{- end }}
+        </ol>
+      </div>
+    </div>
+  </div>
+  {{- with .Content }}
+  <div class="article-body recipe-note">
+    {{ . }}
+  </div>
+  {{- end }}
+</section>
+{{- end }}{{/* end main */}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,14 @@
+{{- define "main" }}
+{{- $feedSections := slice "posts" "photos" "food" }}
+{{- $items := where site.RegularPages "Section" "in" $feedSections }}
+{{- $items = $items.ByDate.Reverse }}
+<section class="feed">
+  {{- if $items }}
+  {{- range $items }}
+  {{- partial "feed-item.html" . }}
+  {{- end }}
+  {{- else }}
+  <p>Nothing published yet.</p>
+  {{- end }}
+</section>
+{{- end }}{{/* end main */}}

--- a/layouts/index.rss.xml
+++ b/layouts/index.rss.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+{{- $feedSections := slice "posts" "photos" "food" }}
+{{- $items := where site.RegularPages "Section" "in" $feedSections }}
+{{- $items = $items.ByDate.Reverse }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ site.Title }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>{{ site.Params.description }}</description>
+    <generator>Hugo -- gohugo.io</generator>
+    {{- with site.Language.Locale }}
+    <language>{{ . }}</language>
+    {{- end }}
+    {{- if not .Date.IsZero }}
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
+    {{- end }}
+    {{- with .OutputFormats.Get "RSS" }}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{- end }}
+    {{- range $items }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ with .Params.externalURL }}{{ . }}{{ else }}{{ .Permalink }}{{ end }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ with .Params.description }}{{ . }}{{ else }}{{ .Summary | html }}{{ end }}</description>
+    </item>
+    {{- end }}
+  </channel>
+</rss>

--- a/layouts/page.html
+++ b/layouts/page.html
@@ -1,0 +1,8 @@
+{{- define "main" }}
+<section class="page-section">
+  <h1 class="title">{{ .Title }}</h1>
+  <div class="page-body">
+    {{ .Content }}
+  </div>
+</section>
+{{- end }}{{/* end main */}}

--- a/layouts/photos/list.html
+++ b/layouts/photos/list.html
@@ -1,0 +1,19 @@
+{{- define "main" }}
+<section class="projects-section">
+  <h1>{{ .Title }}</h1>
+  <p class="sub">{{ with .Params.description }}{{ . }}{{ else }}Galleries from what I've been up to.{{ end }}</p>
+  <div class="projects-grid">
+    {{- range .Pages.ByDate.Reverse }}
+    <article class="project-card">
+      <h2><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
+      <p>{{ with .Params.description }}{{ . }}{{ else }}{{ .Summary | plainify }}{{ end }}</p>
+      <div class="project-links"><a href="{{ .Permalink }}">View gallery &rarr;</a></div>
+    </article>
+    {{- end }}
+    <article class="project-card empty-state">
+      <div class="eyebrow">More soon</div>
+      <p>Nothing here yet &mdash; the slot's ready, that's fine.</p>
+    </article>
+  </div>
+</section>
+{{- end }}{{/* end main */}}

--- a/layouts/photos/single.html
+++ b/layouts/photos/single.html
@@ -1,0 +1,20 @@
+{{- define "main" }}
+{{- $images := .Resources.ByType "image" }}
+<section class="gallery-section">
+  <h1>{{ .Title }}</h1>
+  {{- with .Params.description }}<p class="sub">{{ . }}</p>{{- end }}
+  <div class="gallery-grid">
+    {{- range $images }}
+    <figure>
+      <a href="{{ .RelPermalink }}" target="_blank" rel="noopener">
+        <img src="{{ .RelPermalink }}" alt="{{ .Params.alt | default .Title }}" loading="lazy">
+      </a>
+      {{- with .Title }}<figcaption>{{ . }}</figcaption>{{- end }}
+    </figure>
+    {{- end }}
+  </div>
+  <div class="article-body">
+    {{ .Content }}
+  </div>
+</section>
+{{- end }}{{/* end main */}}

--- a/layouts/posts/list.html
+++ b/layouts/posts/list.html
@@ -1,0 +1,12 @@
+{{- define "main" }}
+<section class="feed">
+  {{- $pages := .Pages.ByDate.Reverse }}
+  {{- if $pages }}
+  {{- range $pages }}
+  {{- partial "feed-item.html" . }}
+  {{- end }}
+  {{- else }}
+  <p>Nothing published yet.</p>
+  {{- end }}
+</section>
+{{- end }}{{/* end main */}}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -1,0 +1,38 @@
+{{- define "main" }}
+{{- if .Params.externalURL }}
+<div class="article-wrap">
+  <div class="article-head">
+    <div class="feed-meta"><span class="tag">Link</span> {{ .Date.Format "2 Jan 2006" }}</div>
+    <h1 class="title">&rarr; <a href="{{ .Params.externalURL }}" target="_blank" rel="noopener noreferrer">{{ .Title }}</a></h1>
+  </div>
+  <div class="article-body">
+    {{ .Content }}
+    <p><a class="more" href="{{ .Params.externalURL }}" target="_blank" rel="noopener noreferrer">Read the original &rarr;</a></p>
+  </div>
+</div>
+{{- else }}
+{{- $hasHeadings := findRE "<h2" .Content 1 }}
+<div class="article-wrap">
+  <div class="article-head">
+    <div class="feed-meta">
+      <span class="tag">Article</span> {{ .Date.Format "2 Jan 2006" }} &middot; {{ .ReadingTime }} min read
+      <button class="print-btn" onclick="window.print()">Print</button>
+    </div>
+    <h1 class="title">{{ .Title }}</h1>
+    {{- with .Params.preface }}
+    <p class="preface">{{ . }}</p>
+    {{- end }}
+    {{- if $hasHeadings }}
+    <div class="toc" id="toc">
+      <div class="toc-label">Contents</div>
+      {{ .TableOfContents }}
+    </div>
+    {{- end }}
+  </div>
+
+  <div class="article-body">
+    {{ .Content }}
+  </div>
+</div>
+{{- end }}
+{{- end }}{{/* end main */}}

--- a/layouts/projects/list.html
+++ b/layouts/projects/list.html
@@ -1,0 +1,25 @@
+{{- define "main" }}
+<section class="projects-section">
+  <h1>{{ .Title }}</h1>
+  <p class="sub">{{ with .Params.description }}{{ . }}{{ else }}Things I've built and shipped.{{ end }}</p>
+  <div class="projects-grid">
+    {{- range .Pages.ByTitle }}
+    <article class="project-card">
+      <h2>{{ .Title }}</h2>
+      <p>{{ with .Params.summary }}{{ . }}{{ else }}{{ .Summary | plainify }}{{ end }}</p>
+      {{- with .Params.links }}
+      <div class="project-links">
+        {{- range . }}
+        <a href="{{ .url }}" target="_blank" rel="noopener noreferrer">{{ .label }} &rarr;</a>
+        {{- end }}
+      </div>
+      {{- end }}
+    </article>
+    {{- end }}
+    <article class="project-card empty-state">
+      <div class="eyebrow">More soon</div>
+      <p>This is where the next thing lands. Nothing here yet &mdash; the slot's ready, that's fine.</p>
+    </article>
+  </div>
+</section>
+{{- end }}{{/* end main */}}

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -1,0 +1,15 @@
+{{- define "main" }}
+<section class="page-section">
+  <h1 class="title">{{ .Title }}</h1>
+  {{- with .Params.links }}
+  <div class="project-links">
+    {{- range . }}
+    <a href="{{ .url }}" target="_blank" rel="noopener noreferrer">{{ .label }} &rarr;</a>
+    {{- end }}
+  </div>
+  {{- end }}
+  <div class="page-body">
+    {{ .Content }}
+  </div>
+</section>
+{{- end }}{{/* end main */}}


### PR DESCRIPTION
## Summary
- Builds the bespoke theme described in `design/DESIGN.md` / `design/eddarmitage-design-concept.html` directly in `layouts/` and `assets/css/main.css`: preface/TOC/sidenote article template, content-type-tagged home feed (Article/Link/Photos/Food), Writing/Projects/Photos/Food/About nav, empty-state cards for the not-yet-launched Photos and Food sections, and a print stylesheet.
- Removes the PaperMod theme submodule now that the site no longer depends on it.
- Restricts non-home page kinds to `["HTML"]` output — Hugo's default of also emitting RSS per section was scattering stray `/posts/feed.xml`-style files and defeating `uglyURLs` on those sections.
- Preserves existing backward-compat URLs (`/about`, `/archive`, `/YYYY/MM/slug`, `/feed.xml`).

## Test plan
- [x] `hugo --gc --minify` production build succeeds with no warnings
- [x] `hugo server -D` manual route check: home, Writing list, article (with TOC/preface/sidenotes/footnotes/code block), Projects, Photos, Food, About, legacy `/archive`, 404, `/feed.xml`
- [ ] Visual/responsive pass in an actual browser (sidenote breakpoints, print stylesheet) — not done this session, extension wasn't connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)