### PR TITLE
Fix RSS feed XML declaration being HTML-escaped

### DIFF
--- a/layouts/index.rss.xml
+++ b/layouts/index.rss.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 {{- $feedSections := slice "posts" "photos" "food" }}
 {{- $items := where site.RegularPages "Section" "in" $feedSections }}
 {{- $items = $items.ByDate.Reverse }}


### PR DESCRIPTION
## Summary

- `layouts/index.rss.xml` started with a bare literal `<?xml version="1.0" encoding="utf-8" standalone="yes"?>` declaration.
- Hugo renders RSS output through Go's `html/template` engine, whose HTML5-aware tokenizer treats a raw `<?xml...?>` appearing before any element as a "bogus comment" and re-serializes it as escaped text (`&lt;?xml...?&gt;`), corrupting the start of `feed.xml` and making it invalid XML — this is what caused the "Document is empty" parse error reported in #9.
- Fixed by emitting the declaration through `{{ printf "..." | safeHTML }}` instead of literal template text, matching the pattern Hugo's own built-in RSS template uses to avoid exactly this issue.

## Test plan

- [x] Installed the pinned Hugo version (0.165.0, per `wrangler.toml`) and ran `hugo --gc --minify` locally.
- [x] Confirmed `public/feed.xml` now starts with a real `<?xml ...?>` processing instruction instead of escaped entities.
- [x] Verified the generated feed parses as well-formed XML via Python's `xml.dom.minidom`.

Fixes #9

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqBzL9wcnUZknZwZyXUut3)_