### PR TITLE
Fix preview site links resolving to production

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,16 @@ in Safari (desktop and iOS), not just Chromium browsers.
 ## Build & dev
 
 - `hugo server -D` — local dev with drafts.
-- `hugo --gc --minify` — production build (what Cloudflare Pages runs).
+- `./scripts/build.sh` — what Cloudflare Pages runs (both production and
+  preview deployments share this one build command). On the `main` branch it
+  runs the normal `hugo --gc --minify`; on any other branch it additionally
+  passes `-b "$CF_PAGES_URL"` to override `baseURL` with the preview
+  deployment's own `*.pages.dev` URL. Without this, Hugo bakes the production
+  `baseURL` from `hugo.toml` into every `.Permalink`-derived link (RSS,
+  canonical tags, favicons, "continue reading" links, etc.), so preview
+  builds would otherwise link back to production instead of themselves.
+  `CF_PAGES_BRANCH` and `CF_PAGES_URL` are injected automatically by
+  Cloudflare Pages — nothing to configure per-environment.
 - Keep the `HUGO_VERSION` env var on the Cloudflare Pages project in sync with
   whatever Hugo version is used locally/in CI — check `hugo version`.
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Cloudflare Pages build command. Preview deployments must not bake in the
+# production baseURL (see hugo.toml) or every absolute link Hugo generates
+# (.Permalink, RSS, canonical tags, favicons) resolves to eddarmitage.com
+# instead of the preview's own *.pages.dev URL. CF_PAGES_BRANCH and
+# CF_PAGES_URL are injected automatically by Cloudflare Pages.
+set -euo pipefail
+
+if [ "${CF_PAGES_BRANCH:-}" = "main" ]; then
+  hugo --gc --minify
+else
+  hugo --gc --minify -b "${CF_PAGES_URL}"
+fi


### PR DESCRIPTION
hugo.toml hardcodes baseURL to https://eddarmitage.com/, so every
Permalink-derived link (RSS, canonical tags, favicons, feed items, list
pages) baked the production domain into Cloudflare Pages preview builds
too. Add scripts/build.sh as the Pages build command: it overrides
baseURL with the deployment's own CF_PAGES_URL on any branch other than
main, using the branch/URL Cloudflare injects automatically.

Fixes #7