### PR TITLE
Update name to Armitage-King consistently across the site

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Edward Armitage
+Copyright (c) 2023 Edward Armitage-King
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/design/eddarmitage-design-concept.html
+++ b/design/eddarmitage-design-concept.html
@@ -524,7 +524,7 @@ p code, li code{
     <a href="#" title="Instagram"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="3" width="18" height="18" rx="5"/><circle cx="12" cy="12" r="4"/><circle cx="17.5" cy="6.5" r="0.8" fill="currentColor" stroke="none"/></svg></a>
     <a href="#" title="RSS feed"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 11a9 9 0 0 1 9 9"/><path d="M4 4a16 16 0 0 1 16 16"/><circle cx="5" cy="19" r="1"/></svg></a>
   </div>
-  <small>© 2026 Edd Armitage · Built with plain HTML · <a href="#">Colophon</a></small>
+  <small>© 2026 Edd Armitage-King · Built with plain HTML · <a href="#">Colophon</a></small>
 </footer>
 
 </body>

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,6 +1,6 @@
 baseURL = "https://eddarmitage.com/"
 locale = "en-GB"
-title = "Edd Armitage-King - Software Engineer"
+title = "Edd Armitage-King"
 
 uglyURLs = true
 disableKinds = ["taxonomy", "term"]

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,6 +1,6 @@
 baseURL = "https://eddarmitage.com/"
 locale = "en-GB"
-title = "Edd Armitage - Software Engineer"
+title = "Edd Armitage-King - Software Engineer"
 
 uglyURLs = true
 disableKinds = ["taxonomy", "term"]
@@ -31,7 +31,7 @@ disableKinds = ["taxonomy", "term"]
 
 [params]
   description = "The personal website of a software engineer"
-  author = "Edd Armitage"
+  author = "Edd Armitage-King"
   mainSections = ["posts", "photos", "food"]
 
   [params.assets]

--- a/layouts/_partials/footer.html
+++ b/layouts/_partials/footer.html
@@ -2,5 +2,5 @@
   <div class="social">
     {{- partial "social-icons.html" (dict "class" "") }}
   </div>
-  <small>&copy; {{ now.Year }} Edd Armitage</small>
+  <small>&copy; {{ now.Year }} Edd Armitage-King</small>
 </footer>

--- a/static/assets/site.webmanifest
+++ b/static/assets/site.webmanifest
@@ -1,6 +1,6 @@
 {
-    "name": "Edd Armitage",
-    "short_name": "Edd Armitage",
+    "name": "Edd Armitage-King",
+    "short_name": "Edd Armitage-King",
     "icons": [
         {
             "src": "/assets/android-chrome-192x192.png",


### PR DESCRIPTION
## Summary

- Replace remaining "Edd/Edward Armitage" references with "Armitage-King" so the name is consistent everywhere.
- `content/about.md` already used the new name; this updates the site title, footer copyright, webmanifest, `LICENSE.md`, and the design mockup, which still had the old surname.

## Changes

- `LICENSE.md` — copyright holder
- `static/assets/site.webmanifest` — `name` / `short_name`
- `hugo.toml` — site `title` and `params.author`
- `layouts/_partials/footer.html` — footer copyright
- `design/eddarmitage-design-concept.html` — mockup footer copyright

Domain/handle references (`eddarmitage.com`, `github.com/eddarmitage`, etc.) were left as-is since those are URLs/usernames, not the display name.

Closes #10

## Test plan

- [x] Grepped the repo for remaining bare "Armitage" occurrences — none found outside URLs/handles
- [ ] `hugo server -D` not run in this environment (Hugo not installed); changes are plain string replacements with no structural/template risk


---
_Generated by [Claude Code](https://claude.ai/code/session_01HtNQjBoPMWJyHppswUvYts)_