### PR TITLE
Remove stale GitHub Pages CNAME and update README for Hugo/Cloudflare

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-eddarmitage.com

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # Site contents for eddarmitage.com
 
-It's built using GitHub pages, and served via Cloudflare. I've written more details about how I set that up in a blog
-post that you can read [here](https://eddarmitage.com/2023/06/hosting-a-static-site).
-
-Because it's built using GitHub Pages, it's a Jekyll site, and I've kept with the default minima theme. GitHub seems to
-currently be using v2.5.1 of this theme, so the documentation is available [here][Minima-docs].
+It's a [Hugo](https://gohugo.io) site with a custom theme (implemented directly in `layouts/` and
+`assets/css/main.css`), built and served by Cloudflare Pages. It was originally built using GitHub Pages and Jekyll —
+I've written more details about that original setup in a blog post that you can read
+[here](https://eddarmitage.com/2023/06/hosting-a-static-site) — but the site has since been migrated to Hugo, with
+Cloudflare Pages handling both build and hosting. See `AGENTS.md` for details of the current setup.
 
 ## License
 The content of this site is licensed under the [Creative Commons Attribution 3.0 Unported license](https://creativecommons.org/licenses/by/3.0/), and the underlying source code used to format and display that content is licensed under the [MIT license](LICENSE.md).
-
-[Minima-docs]: https://github.com/jekyll/minima/blob/v2.5.1/README.md


### PR DESCRIPTION
## Summary

Follow-up cleanup from #8. The site was migrated from Jekyll+GitHub Pages to Hugo+Cloudflare Pages a while back (see #4/#5), but two things were never updated to reflect that:

- The root `CNAME` file — a GitHub Pages custom-domain convention — is no longer needed since the custom domain is now managed through Cloudflare. Removed.
- `README.md` still described the site as "built using GitHub Pages" running Jekyll with the minima theme. Updated to describe the actual Hugo + Cloudflare Pages setup, pointing at `AGENTS.md` for details.

Note: this doesn't disable the GitHub Pages Jekyll build itself — that's a repository **Settings → Pages → Source** change, which needs to be done manually in the GitHub UI (not something a commit can fix). See the discussion on #8.

## Test plan

- [x] Confirmed no other files in the repo reference `CNAME`
- [x] Read through the updated `README.md` for accuracy against `hugo.toml` / `AGENTS.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFRD47dFWsRfAApDEDgPJ7)_