### PR TITLE
Update site header wordmark to Armitage-King

### DIFF
--- a/design/eddarmitage-design-concept.html
+++ b/design/eddarmitage-design-concept.html
@@ -343,7 +343,7 @@ p code, li code{
 </div>
 
 <header class="site-header">
-  <a class="wordmark" href="#">edd armitage<span>.</span></a>
+  <a class="wordmark" href="#">edd armitage-king<span>.</span></a>
   <nav>
     <a href="#">Writing</a>
     <a href="#projects">Projects</a>

--- a/layouts/_partials/header.html
+++ b/layouts/_partials/header.html
@@ -1,5 +1,5 @@
 <header class="site-header">
-  <a class="wordmark" href="{{ "/" | relURL }}">edd armitage<span>.</span></a>
+  <a class="wordmark" href="{{ "/" | relURL }}">edd armitage-king<span>.</span></a>
   <nav>
     {{- range site.Menus.main }}
     <a href="{{ .URL }}" {{ if $.IsMenuCurrent "main" . }}aria-current="page"{{ end }}>{{ .Name }}</a>


### PR DESCRIPTION
## Summary

- Follow-up to #13: the site header "wordmark" (top-left link, `edd armitage.`) was missed in that pass and still showed the old surname.
- Updates both the live template and its matching mockup so they stay in sync.

## Changes

- `layouts/_partials/header.html` — wordmark text
- `design/eddarmitage-design-concept.html` — matching wordmark in the design reference

Relates to #10

## Test plan

- [x] Grepped the repo for remaining "armitage" occurrences — only domain/handle references (`eddarmitage.com`, GitHub username, etc.) remain, which is intentional
- [ ] `hugo server -D` not run in this environment (Hugo not installed); change is a plain string replacement with no structural/template risk


---
_Generated by [Claude Code](https://claude.ai/code/session_01HtNQjBoPMWJyHppswUvYts)_