### PR TITLE
Preserve paragraph breaks in homepage feed summaries

### DIFF
--- a/layouts/_partials/feed-item.html
+++ b/layouts/_partials/feed-item.html
@@ -18,7 +18,7 @@
     <a href="{{ $href }}">{{ .Title }}</a>
     {{- end }}
   </h3>
-  <p>{{ with .Params.description }}{{ . }}{{ else }}{{ .Summary | plainify }}{{ end }}</p>
+  <div class="summary">{{ with .Params.description }}<p>{{ . }}</p>{{ else }}{{ .Summary }}{{ end }}</div>
   {{- if eq $tag "Article" }}
   <a class="more" href="{{ .Permalink }}">Continue reading &rarr;</a>
   {{- end }}


### PR DESCRIPTION
## Summary

- Fixes #22: multi-paragraph auto-generated summaries on the homepage feed were losing their paragraph breaks.
- `layouts/_partials/feed-item.html` used `.Summary | plainify` inside a single `<p>`. `.Summary` is Hugo-rendered HTML, and `plainify` strips block-level tags (like the `<p>` boundaries between paragraphs) without substituting any separator, so paragraphs got concatenated into one run-on block.
- Changed the card to render `.Summary` directly as HTML inside a wrapping `<div class="summary">`, so nested `<p>` tags from a multi-paragraph summary stay valid HTML and paragraph breaks are preserved. This is the second option suggested in the issue. The explicit `description` front-matter path still renders as a plain `<p>`.
- No CSS changes needed — `.feed-item p` is a descendant selector, so it already applies to `<p>` tags nested inside the new `.summary` div.

## Test plan

- [x] Built the site locally with the pinned Hugo version (`v0.165.0`, from `wrangler.toml`) and confirmed the homepage feed card for `content/posts/hosting-a-static-site.md` now renders its two-paragraph summary as two separate `<p>` tags inside `.summary`, instead of one run-on paragraph.
- [x] Verified with `hugo -D` that the draft post's summary also renders as valid, well-formed HTML.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ku14QJQHNjuvFYqgB6bZ8t)_