### PR TITLE
Add CI: Hugo build check, markdown lint, link checking, image size check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,5 +66,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install ImageMagick
+        run: sudo apt-get update && sudo apt-get install -y imagemagick
+
       - name: Check image sizes
         run: ./scripts/check-image-sizes.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: "0.165.0"
+          extended: true
+
+      - name: Build site
+        run: ./scripts/build.sh
+        env:
+          CF_PAGES_BRANCH: main
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: public
+          path: public
+          retention-days: 1
+
+  markdown-lint:
+    name: Markdown lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DavidAnson/markdownlint-cli2-action@v19
+        with:
+          globs: "content/**/*.md"
+
+  link-check:
+    name: Link check
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: public
+          path: public
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --offline
+            --base-url ${{ github.workspace }}/public
+            --remap "https://eddarmitage.com/ file://${{ github.workspace }}/public/"
+            --fallback-extensions html
+            ./public
+          fail: true
+
+  image-size-check:
+    name: Image size check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check image sizes
+        run: ./scripts/check-image-sizes.sh

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,14 @@
+{
+  // Front matter here is YAML (---), which markdownlint-cli2 recognises by
+  // default - see AGENTS.md.
+  "config": {
+    "default": true,
+    // Prose content isn't wrapped to a fixed line length.
+    "MD013": false,
+    // Posts don't open with a top-level heading - the title comes from
+    // front matter instead.
+    "MD041": false,
+    // Shortcode/HTML snippets are occasionally embedded directly in content.
+    "MD033": false
+  }
+}

--- a/content/posts/how-i-serve-my-website.md
+++ b/content/posts/how-i-serve-my-website.md
@@ -4,9 +4,6 @@ date: 2025-12-05
 draft: true
 ---
 
-How I Serve My Website
-=====================
-
 This is my first post and outlines how I serve my website. It's a static site, generated using Hugo, and served via Cloudflare.
 
 Hugo

--- a/content/projects/home-network.md
+++ b/content/projects/home-network.md
@@ -5,7 +5,4 @@ draft: true
 summary: "Ubiquiti gear, VLANs for Sonos and Home Assistant, and the write-up of getting it all to play nicely together."
 ---
 
-My Home Network
-===============
-
 I run  home network using Ubiqiti equipment. Setting it up with appropriate VLANs to run Sonos and Home Assistant was a bit of a challenge, so I've written everything up here.

--- a/scripts/check-image-sizes.sh
+++ b/scripts/check-image-sizes.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Fails if any image under content/ or static/ exceeds MAX_DIMENSION pixels
+# on its longest edge - a guardrail against accidentally committing
+# full-size source photos into the repo. Requires ImageMagick's `identify`
+# (preinstalled on GitHub-hosted ubuntu-latest runners).
+set -euo pipefail
+
+MAX_DIMENSION=2000
+FAILED=0
+
+while IFS= read -r -d '' file; do
+  dimensions=$(identify -format "%w %h\n" "$file" 2>/dev/null | head -n1)
+  if [ -z "$dimensions" ]; then
+    echo "warning: could not read dimensions for $file" >&2
+    continue
+  fi
+
+  width=${dimensions% *}
+  height=${dimensions#* }
+  longest=$(( width > height ? width : height ))
+
+  if [ "$longest" -gt "$MAX_DIMENSION" ]; then
+    echo "::error file=${file}::Image exceeds ${MAX_DIMENSION}px on its longest edge (${width}x${height})"
+    FAILED=1
+  fi
+done < <(find content static -type f \( \
+    -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' \
+    -o -iname '*.webp' -o -iname '*.gif' \
+  \) -print0)
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "One or more images exceed the ${MAX_DIMENSION}px limit on their longest edge." >&2
+  exit 1
+fi
+
+echo "All images are within the ${MAX_DIMENSION}px limit."

--- a/scripts/check-image-sizes.sh
+++ b/scripts/check-image-sizes.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 # Fails if any image under content/ or static/ exceeds MAX_DIMENSION pixels
 # on its longest edge - a guardrail against accidentally committing
-# full-size source photos into the repo. Requires ImageMagick's `identify`
-# (preinstalled on GitHub-hosted ubuntu-latest runners).
+# full-size source photos into the repo. Requires ImageMagick's `identify`.
 set -euo pipefail
 
 MAX_DIMENSION=2000


### PR DESCRIPTION
## Summary

Implements #27 in full: adds `.github/workflows/ci.yml` running four independent jobs on `pull_request` against `main`, plus the supporting config/scripts.

- **build** — `./scripts/build.sh` with Hugo pinned to `wrangler.toml`'s `HUGO_VERSION` (`0.165.0`), uploading `public/` as an artifact. Sets `CF_PAGES_BRANCH=main` so the script's Cloudflare-Pages-specific branching (which otherwise requires `CF_PAGES_URL` to be injected) takes the plain production-build path.
- **markdown-lint** — `content/**/*.md` via `DavidAnson/markdownlint-cli2-action`, using `.markdownlint-cli2.jsonc` (relaxes rules that don't suit this site's prose: line length, first-line heading, inline HTML).
- **link-check** — `lychee` against the built `public/` output in `--offline` mode, with `--base-url`/`--remap`/`--fallback-extensions html` so this site's absolute `eddarmitage.com` links and `uglyURLs`-style extensionless paths (`/about` → `about.html`) resolve correctly.
- **image-size-check** — `scripts/check-image-sizes.sh` fails if any image under `content/` or `static/` exceeds 2000px on its longest edge. Installs ImageMagick explicitly (it turned out not to be preinstalled on the runner, despite the assumption in an earlier draft of this PR — the job failed with exit 127 until fixed).

Also removes a redundant manual `H1` from two draft posts (`content/posts/how-i-serve-my-website.md`, `content/projects/home-network.md`) that duplicated the front-matter `title` — `layouts/posts/single.html` already renders `.Title` separately, so the extra heading was both redundant output and a markdownlint MD025 violation.

### Validation

All four checks were run and verified locally before pushing, including deliberately-broken-link and oversized-image test cases to confirm each check actually fails when it should. The workflow itself is now green on this PR (see checks below).

Closes #27.

---
_Generated by [Claude Code](https://claude.ai/code/session_0113y2mzAvvrs5iJPU7e3N7f)_