### PR TITLE
Change post URL scheme from /YYYY/MM/slug to /YYYY/slug

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,11 +51,15 @@ The custom theme is implemented directly in `layouts/` and `assets/css/main.css`
 ## URL structure — do not change without checking backward-compat
 
 `hugo.toml` sets `uglyURLs = true` plus a custom `posts` permalink
-specifically to reproduce the exact URLs the old Jekyll site served
-(`/about`, `/archive`, `/YYYY/MM/slug`, no trailing slash) once Cloudflare
-Pages strips the `.html` extension at the edge. Changing permalink structure
-or `uglyURLs` will break existing indexed/bookmarked URLs — treat this as a
-deliberate constraint, not an oversight.
+(`/YYYY/slug`, no trailing slash) once Cloudflare Pages strips the `.html`
+extension at the edge. This originally reproduced the old Jekyll site's
+`/YYYY/MM/slug` scheme exactly; that month segment was deliberately dropped
+in #36, with 301s in `static/_redirects` covering every post that was
+already published under the old scheme so existing indexed/bookmarked links
+keep working. Changing permalink structure or `uglyURLs` again will break
+current indexed/bookmarked URLs — treat this as a deliberate constraint, not
+an oversight, and add a corresponding `static/_redirects` entry for any
+already-published URL a future change would move.
 
 RSS is intentionally served at `/feed.xml` (via an `outputFormats.RSS`
 override in `hugo.toml`), matching the feed URL that was actually live under

--- a/hugo.toml
+++ b/hugo.toml
@@ -6,7 +6,7 @@ uglyURLs = true
 disableKinds = ["taxonomy", "term"]
 
 [permalinks]
-  posts = "/:year/:month/:slug"
+  posts = "/:year/:slug"
 
 [outputFormats.RSS]
   mediaType = "application/rss+xml"

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,7 @@
+# Posts moved from /:year/:month/:slug to /:year/:slug (see AGENTS.md "URL
+# structure" and issue #36). One line per existing published post — add a
+# line here whenever an old-scheme URL needs to keep working, rather than
+# relying on a pattern rule, since a flat /:year/*/:slug -> /:year/:slug
+# rewrite would only be safe if no two months in the same year ever share a
+# slug.
+/2023/06/hosting-a-static-site /2023/hosting-a-static-site 301


### PR DESCRIPTION
## Summary
- Drop the month segment from the `posts` permalink in `hugo.toml`: `/:year/:month/:slug` → `/:year/:slug`.
- Add `static/_redirects` with a 301 for the one currently-published post (`hosting-a-static-site`, 2023-06-17) so its existing indexed/bookmarked URL keeps working. The other two posts in `content/posts/` are still `draft: true`, so they've never had a live old-scheme URL and need no redirect entry.
- Update `AGENTS.md`'s "URL structure" section to describe the new scheme and document the redirect mechanism for future changes.

## Test plan
- [x] `hugo --gc -D` and `hugo --gc --minify` both build cleanly.
- [x] Confirmed locally that the post now publishes at `/2023/hosting-a-static-site` in the build output.
- [x] Checked `layouts/_partials/qr.html` and the RSS/feed templates — both build URLs off `.Permalink`/`.RelPermalink`, so no changes needed there.
- [ ] Verify the 301 redirect works on a Cloudflare Pages preview deployment (not testable via local `hugo server`, which doesn't serve `_redirects`).

Closes #36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)