### PR TITLE
Add Dependabot config for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+
+# GitHub Actions is the only dependency ecosystem in this repo — the site is
+# pure Hugo (no package manager, no theme submodule), so the action versions
+# pinned in .github/workflows/ci.yml are the only thing to keep current.
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    # One PR for the lot: these are all CI-only bumps, and CI runs the full
+    # build/lint/link-check on it anyway, so reviewing them together is cheaper
+    # than four near-identical PRs a week.
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Sets up Dependabot for this repo.

GitHub Actions is the only dependency ecosystem here — the site is pure Hugo with no package manager and no theme submodule, so the action versions pinned in `.github/workflows/ci.yml` (`actions/checkout`, `actions/upload-artifact`, `actions/download-artifact`, `peaceiris/actions-hugo`, `DavidAnson/markdownlint-cli2-action`, `lycheeverse/lychee-action`) are the only thing there is to keep current.

- Weekly, Monday mornings, Europe/London.
- All actions grouped into a **single** PR rather than one each: they're CI-only bumps, and the existing CI workflow builds the site, lints markdown, checks links and checks image sizes on the grouped PR anyway.
- `ci` commit-message prefix.

Note that Dependabot won't touch the pinned `hugo-version: "0.165.0"` in the workflow, or the `HUGO_VERSION` env var on the Cloudflare Pages project — those stay a manual, deliberately-in-sync pair per AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dj2oMnddKBouYejAaTndP